### PR TITLE
Add dotenv support and example environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+
+# Session Secret - Use a random, secure string for production
+SESSION_SECRET=your-session-secret-here
+
+# Database Configuration (if needed)
+# DATABASE_URL=your-database-url-here
+
+# Add other environment variables as needed

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+
+# Environment variables
+.env
+.env.local
+.env.production

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.0.0",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.3.0",
@@ -4260,6 +4261,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
-    
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -49,6 +48,7 @@
     "cmdk": "^1.0.0",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.3.0",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -49,7 +49,7 @@ async function comparePasswords(supplied: string, stored: string) {
  */
 export function setupAuth(app: Express) {
   const sessionSettings: session.SessionOptions = {
-    secret: process.env.SESSION_SECRET!, // Should be set in environment
+    secret: process.env.SESSION_SECRET || "dev-secret-change-in-production", // Fallback for development
     resave: false,
     saveUninitialized: false,
     store: storage.sessionStore,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@
 // Main entry point for the Express backend server.
 // Sets up middleware, logging, error handling, and serves both API and frontend.
 
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
@@ -64,11 +65,7 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 3000
   // This serves both the API and the client
   const port = 3000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
+  server.listen(port, "0.0.0.0", () => {
     log(`serving on port ${port}`);
   });
 })();


### PR DESCRIPTION
Introduce dotenv for environment variable management and create an example `.env` file for configuration. Update session secret handling to provide a fallback for development.